### PR TITLE
Add comma to Harvest tagline

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ layout: base
         <div class=col-sm-12>
             <div class=jumbotron>
                 <h1>Data Discovery For Humans</h1>
-                <h2>Explore your data not your database.</h2>
+                <h2>Explore your data, not your database.</h2>
                 <p>Designed by and for biomedical researchers, The Harvest Stack is an <strong>open source BSD-licensed</strong> toolkit for building web applications for integrating, discovering, and reporting data.</p>
                 <p><a class="btn btn-success" href="{{ site.baseurl }}demo/" target=_blank><i class="icon-cloud"></i> Try the Demo</a> <!--<a class="btn btn-primary" href="{{ site.baseurl }}media/"><i class="icon-play-sign"></i> Watch &amp; Learn</a>--></p>
             </div>


### PR DESCRIPTION
Regardless of formal correctness, as a slogan, this reads much better to me with a comma.  It's punchier and emphasizes the main point, "explore your data."  Even if marketing materials have escaped into the wild without a comma, Harvest is going to be around for a long time, and I think it's worth making the change.
