### PR TITLE
Removed "(this is real)" from "Nationally Funded"

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@ layout: base
             </div>
 
             <div class=col-md-6>
-                <h3><i class="fa fa-trophy"></i> Nationally Funded (This is Real)</h3>
+                <h3><i class="fa fa-trophy"></i> Nationally Funded</h3>
                 <p>National Human Genome Research Institute (NHGRI), National Institute on Deafness and Other Communication Disorders (NIDCD), National Heart, Lung and Blood Institute (NHLBI), <a href="{{ site.baseurl }}resources/">and others</a> have funded Harvest applications.</p>
             </div>
         </div>


### PR DESCRIPTION
I don't think this is necessary, and feels a little defensive. Jeff P commented to me about it as well, so I figured since it was more than just me it was worth a PR.
